### PR TITLE
Temporary fixes for some trigger and saving issues

### DIFF
--- a/brunoise/external_communication.py
+++ b/brunoise/external_communication.py
@@ -23,7 +23,7 @@ class ZMQcomm:
             poller = zmq.Poller()
             poller.register(zmq_socket, zmq.POLLIN)
             duration = None
-            if poller.poll(1000):
+            if poller.poll(5000):
                 duration = zmq_socket.recv_json()
             zmq_socket.close()
 

--- a/brunoise/objective_motor.py
+++ b/brunoise/objective_motor.py
@@ -37,6 +37,10 @@ class MotorControl:
         except pyvisa.VisaIOError:
             print(f"Error get position axes number {self.axes} ")
             return None
+        
+    def send_command(self, command):
+        # "MO": motor on, "MF": off
+        self.execute_motor(self.axes + command)
 
     def move_abs(self, coordinate):
         coordinate = str(coordinate)

--- a/brunoise/state.py
+++ b/brunoise/state.py
@@ -205,6 +205,7 @@ class ExperimentState(QObject):
         if not force and self.save_status.i_z + 1 < self.save_status.target_params.n_z:
             self.advance_plane()
         else:
+            sleep(0.2)
             self.saver.saving_signal.clear()
             self.motors["z"].send_command("MO")
             if self.pause_after:

--- a/brunoise/state.py
+++ b/brunoise/state.py
@@ -42,7 +42,7 @@ class ScanningSettings(ParametrizedQt):
         super().__init__()
         self.name = "scanning"
         self.aspect_ratio = Param(1.0, (0.2, 5.0))
-        self.voltage = Param(3.0, (0.2, 4.0))
+        self.voltage = Param(3.0, (0.2, 5.0))
         self.framerate = Param(2.0, (0.1, 10.0))
         self.reset_shutter = Param(False)
         self.binning = Param(10, (1, 50))

--- a/brunoise/state.py
+++ b/brunoise/state.py
@@ -259,6 +259,7 @@ class ExperimentState(QObject):
                     and self.save_status.i_t + 1 == self.save_status.target_params.n_t
                 ):
                     self.end_experiment()
+                    self.save_status.i_t = -5
                 self.save_queue.put(images)
                 self.timestamp_queue.put(t)
             return images

--- a/brunoise/state.py
+++ b/brunoise/state.py
@@ -196,6 +196,7 @@ class ExperimentState(QObject):
             self.send_save_params()
             self.saver.saving_signal.set()
         self.experiment_start_event.set()
+        self.motors["z"].send_command("MF")
         return True
 
     def end_experiment(self, force=False):
@@ -205,6 +206,7 @@ class ExperimentState(QObject):
             self.advance_plane()
         else:
             self.saver.saving_signal.clear()
+            self.motors["z"].send_command("MO")
             if self.pause_after:
                 self.pause_scanning()
             else:
@@ -225,6 +227,7 @@ class ExperimentState(QObject):
         self.paused = True
 
     def advance_plane(self):
+        self.motors["z"].send_command("MO")
         self.motors["z"].move_rel(self.experiment_settings.dz / 1000)
         sleep(0.2)
         self.start_experiment(first_plane=False)

--- a/brunoise/streaming_save.py
+++ b/brunoise/streaming_save.py
@@ -10,6 +10,7 @@ import json
 import yagmail
 from PIL import Image
 import os
+import time
 
 
 @dataclass
@@ -100,7 +101,16 @@ class StackSaver(Process):
                 i_received += 1
             except Empty:
                 pass
-
+        
+        t_end = time.time()
+        while time.time() - t_end < 5:
+            try:
+                frame = self.data_queue.get(timeout=0.01)
+                self.fill_dataset(frame)
+                break
+            except Empty:
+                pass
+        
         if self.i_block > 0:
             self.finalize_dataset()
             if self.save_parameters.notification_email != "None":


### PR DESCRIPTION
Dirty fixes made for the following issues:
1. It stops because it didn't receive data from stytra during the waiting time (1 s) at the beginning of a plane. The time it takes ranges from 6 ms to at least 2.5 s. Solved by waiting 5 seconds.
2. It creates the splitdataset without the last plane because it finishes before receiving the last frame of the last plane. Solved by waiting 5 seconds for the last frame.
3. It moves double the z step size when moving to the next plane because it triggers the motor twice. Solved by forcing the internal frame count to have a small number once the z motor is moved.
(4. Sometimes the z motor moves unintentionally during imaging. Not sure if it's a software problem, but now the motor is turned off after starting a plane.)